### PR TITLE
Force requests library to have version < 1.0.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,6 @@ setup(
     platforms='any',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=['Sphinx>=1.1', 'requests>=0.13'],
+    install_requires=['Sphinx>=1.1', 'requests>=0.13,<1.0.3'],
     namespace_packages=['sphinxcontrib'],
 )


### PR DESCRIPTION
As of version 1.0.3, the `requests` library allows parsing JSON from a response `r` via the function invocation `r.json()`. Before version 1.0.3, it allowed parsing JSON from a response `r` via the property `r.json`. Currently, `sphinxcontrib-issuetracker` uses the latter. Therefore, the `requests` library version must not be 1.0.3 or greater.

(An alternate solution would be to change all instances of `r.json` to `r.json()` in `sphinxcontrib-issuetracker`, and require the version of the `requests` library to be at least 1.0.3.)
