### PR TITLE
[setup] return meta data to sphinx (version, parallel read/write=True)

### DIFF
--- a/sphinxcontrib/issuetracker/__init__.py
+++ b/sphinxcontrib/issuetracker/__init__.py
@@ -332,4 +332,10 @@ def setup(app):
     app.connect(str('builder-inited'), init_transformer)
     app.connect(str('doctree-read'), lookup_issues)
     app.connect(str('missing-reference'), resolve_issue_reference)
-    app.connect(str('build-finished'), copy_stylesheet)
+    app.connect(str('build-finished'), copy_stylesheet) 
+    # return metadata to sphinx
+    metadata = dict(version=__version__,
+                    parallel_read_safe=True,
+                    parallel_write_safe=True,
+                   )
+    return metadata


### PR DESCRIPTION
This enables parallel read and write. I've tested it locally with a huge documentation and works fine.
