### PR TITLE
Set refdomain for refnodes to fix build with Sphinx 1.6.3

### DIFF
--- a/sphinxcontrib/issuetracker/__init__.py
+++ b/sphinxcontrib/issuetracker/__init__.py
@@ -158,6 +158,7 @@ class IssueReferences(Transform):
                 issue_id = match.group(1)
                 # turn the issue reference into a reference node
                 refnode = pending_xref()
+                refnode['refdomain'] = None
                 refnode['reftarget'] = issue_id
                 refnode['reftype'] = 'issue'
                 refnode['trackerconfig'] = tracker_config


### PR DESCRIPTION
Otherwise the documentation build and tests fail with:
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/sphinx/cmdline.py", line 306, in main
    app.build(opts.force_all, filenames)
  File "/usr/lib/python2.7/dist-packages/sphinx/application.py", line 339, in build
    self.builder.build_update()
  File "/usr/lib/python2.7/dist-packages/sphinx/builders/__init__.py", line 331, in build_update
    'out of date' % len(to_build))
  File "/usr/lib/python2.7/dist-packages/sphinx/builders/__init__.py", line 344, in build
    updated_docnames = set(self.env.update(self.config, self.srcdir, self.doctreedir))
  File "/usr/lib/python2.7/dist-packages/sphinx/environment/__init__.py", line 584, in update
    self._read_serial(docnames, self.app)
  File "/usr/lib/python2.7/dist-packages/sphinx/environment/__init__.py", line 603, in _read_serial
    self.read_doc(docname, app)
  File "/usr/lib/python2.7/dist-packages/sphinx/environment/__init__.py", line 730, in read_doc
    domain.process_doc(self, docname, doctree)
  File "/usr/lib/python2.7/dist-packages/sphinx/domains/std.py", line 576, in process_doc
    self.note_citation_refs(env, docname, document)
  File "/usr/lib/python2.7/dist-packages/sphinx/domains/std.py", line 593, in note_citation_refs
    if node['refdomain'] == 'std' and node['reftype'] == 'citation':
  File "/usr/lib/python2.7/dist-packages/docutils/nodes.py", line 567, in __getitem__
    return self.attributes[key]
KeyError: 'refdomain'
```

This is a result of sphinx-doc/sphinx@69b090f3c503a5bb4131a9b5a9827ac9d692c2fe.