### PR TITLE
[Fix #17] redmine resolver deal w/ no issue #

### DIFF
--- a/sphinxcontrib/issuetracker/resolvers.py
+++ b/sphinxcontrib/issuetracker/resolvers.py
@@ -202,6 +202,7 @@ def lookup_jira_issue(app, tracker_config, issue_id):
 
 def lookup_redmine_issue(app, tracker_config, issue_id):
     from redmine import Redmine
+    import redmine.exceptions as redmine_exceptions
     if not tracker_config.url:
         raise ValueError('URL required')
     redmine = Redmine(tracker_config.url,
@@ -210,7 +211,11 @@ def lookup_redmine_issue(app, tracker_config, issue_id):
                       password=app.config.issuetracker_redmine_password,
                       requests=app.config.issuetracker_redmine_requests)
     if redmine:
-        issue = redmine.issue.get(issue_id)
+        try:
+            issue = redmine.issue.get(issue_id)
+        except redmine_exceptions.ResourceNotFoundError:
+            # requested issue number not found
+            return None
         return Issue(id=issue_id, title=issue.subject,
                      closed=issue.status is "Closed",
                      url=issue.url)


### PR DESCRIPTION
Like the other resolvers, the redmine resolver will
now return None if the requested issue isn't found
in the registered redmine project.

Note:- doesn't look like there is a unit test yet for redmine in tests/test_buildin_trackers.py

I started working on adding one there, but then it actually seemed a lot bigger job than this one-liner fix.