### PR TITLE
[Fix #19] redmine resolver to get closed status.

### DIFF
--- a/sphinxcontrib/issuetracker/resolvers.py
+++ b/sphinxcontrib/issuetracker/resolvers.py
@@ -211,8 +211,9 @@ def lookup_redmine_issue(app, tracker_config, issue_id):
                       requests=app.config.issuetracker_redmine_requests)
     if redmine:
         issue = redmine.issue.get(issue_id)
+        is_closed = str(issue.status).title() == "Closed"
         return Issue(id=issue_id, title=issue.subject,
-                     closed=issue.status is "Closed",
+                     closed=is_closed,
                      url=issue.url)
 
 BUILTIN_ISSUE_TRACKERS = {


### PR DESCRIPTION
Tested using python-redmine v1.5 but consistent with
latest python-redmine docs, see
https://python-redmine.com/resources/issue_status.html.

issue status in python-redmine isn't a string it's now
a class, but calling str() on it makes it
backwards-compatible with prev.  approach.