### PR TITLE
avoid injecting xrefs inside other xrefs

### DIFF
--- a/sphinxcontrib/issuetracker/__init__.py
+++ b/sphinxcontrib/issuetracker/__init__.py
@@ -135,6 +135,9 @@ class IssueReferences(Transform):
             if isinstance(parent, (nodes.literal, nodes.FixedTextElement)):
                 # ignore inline and block literal text
                 continue
+            if isinstance(parent, nodes.reference):
+                # we don't want to inject a link inside another link
+                continue
             text = text_type(node)
             new_nodes = []
             last_issue_ref_end = 0


### PR DESCRIPTION
In my project, I wanted to make a link to *another* project's issue, like this:

    `Greenwave issue #126 <https://pagure.io/greenwave/issue/126>`_

but this extension was still picking up on the `#126` portion of the reference and converting that into a reference inside a reference.

I don't think it ever makes sense to produce nested links like that, so this patch makes the extension just skip reference nodes entirely (in the same way it skips literal nodes).